### PR TITLE
feat: v20 API, recipe endpoints, consumed types, user API Zod tests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -20,5 +20,9 @@ export { getUserGoals } from "@/api/user/goals";
 export { getUserSettings } from "@/api/user/settings";
 export { getUserDailySummary } from "@/api/user/summary";
 export { getUserWaterIntake } from "@/api/user/water";
-export { getRecipe, deleteUserRecipe } from "@/api/user/recipes";
+export {
+  getRecipe,
+  getUserRecipeIds,
+  deleteUserRecipe,
+} from "@/api/user/recipes";
 export { getUser } from "@/api/user";

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,7 @@
-export { getTokenFromCredentials } from "@/api/oauth/token";
+export {
+  getTokenFromCredentials,
+  getTokenFromRefreshToken,
+} from "@/api/oauth/token";
 
 export { getProduct } from "@/api/products";
 export { searchProducts } from "@/api/products/search";

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,4 +17,5 @@ export { getUserGoals } from "@/api/user/goals";
 export { getUserSettings } from "@/api/user/settings";
 export { getUserDailySummary } from "@/api/user/summary";
 export { getUserWaterIntake } from "@/api/user/water";
+export { getRecipe, deleteUserRecipe } from "@/api/user/recipes";
 export { getUser } from "@/api/user";

--- a/src/api/oauth/token.ts
+++ b/src/api/oauth/token.ts
@@ -37,3 +37,35 @@ export const getTokenFromCredentials = async (
     expires_at: Date.now() + token.expires_in * 1000,
   };
 };
+
+/**
+ * Refresh an access token using a refresh token.
+ * Uses the same /oauth/token endpoint with grant_type: "refresh_token".
+ *
+ * @param refreshToken - The refresh_token from a previous auth response.
+ *
+ * @returns - Promise resolving to a new Token (access_token, refresh_token, expires_in).
+ */
+export const getTokenFromRefreshToken = async (
+  refreshToken: string
+): Promise<Token> => {
+  if (!refreshToken)
+    throw new Error("Missing refresh_token. Cannot refresh.");
+
+  const token = await fetchYazio<
+    Pick<Token, "token_type" | "access_token" | "refresh_token" | "expires_in">
+  >(`/oauth/token`, {
+    method: "POST",
+    body: JSON.stringify({
+      client_id: YAZIO_CLIENT_ID,
+      client_secret: YAZIO_CLIENT_SECRET,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  return {
+    ...token,
+    expires_at: Date.now() + token.expires_in * 1000,
+  };
+};

--- a/src/api/user/consumed.ts
+++ b/src/api/user/consumed.ts
@@ -25,6 +25,40 @@ export const UserConsumedItemSchema = z.object({
 
 export type UserConsumedItem = z.infer<typeof UserConsumedItemSchema>;
 
+export const RecipePortionConsumedItemSchema = z.object({
+  id: z.string().uuid(),
+  date: z.string(),
+  daytime: DaytimeSchema,
+  type: z.literal("recipe_portion"),
+  recipe_id: z.string().uuid(),
+  portion_count: z.number(),
+});
+export type RecipePortionConsumedItem = z.infer<
+  typeof RecipePortionConsumedItemSchema
+>;
+
+export const SimpleProductConsumedItemSchema = z.object({
+  id: z.string().uuid(),
+  date: z.string(),
+  daytime: DaytimeSchema,
+  type: z.literal("simple_product"),
+  name: z.string(),
+  nutrients: z.record(z.string(), z.number()),
+  is_ai_generated: z.boolean(),
+});
+export type SimpleProductConsumedItem = z.infer<
+  typeof SimpleProductConsumedItemSchema
+>;
+
+export const GetUserConsumedItemsResponseSchema = z.object({
+  products: z.array(UserConsumedItemSchema),
+  recipe_portions: z.array(RecipePortionConsumedItemSchema),
+  simple_products: z.array(SimpleProductConsumedItemSchema),
+});
+export type GetUserConsumedItemsResponse = z.infer<
+  typeof GetUserConsumedItemsResponseSchema
+>;
+
 /**
  * Get the consumed items of the user, optionally for a specific day.
  *
@@ -36,13 +70,8 @@ export type UserConsumedItem = z.infer<typeof UserConsumedItemSchema>;
 export const getUserConsumedItems = async (
   token: Token,
   options?: GetUserConsumedItemsOptions
-): Promise<{
-  products: Array<UserConsumedItem>;
-  // TODO (@juriadams): Type recipes.
-  recipe_portions: Array<unknown>;
-  simple_products: Array<unknown>;
-}> =>
-  fetchYazio(
+): Promise<GetUserConsumedItemsResponse> =>
+  fetchYazio<GetUserConsumedItemsResponse>(
     `/user/consumed-items?date=${parseDate(options?.date ?? new Date())}`,
     {
       headers: {

--- a/src/api/user/goals.ts
+++ b/src/api/user/goals.ts
@@ -9,7 +9,7 @@ const GetUserGoalsOptionsSchema = z.object({
 
 type GetUserGoalsOptions = z.infer<typeof GetUserGoalsOptionsSchema>;
 
-const UserGoalsSchema = z.object({
+export const UserGoalsSchema = z.object({
   "energy.energy": z.number(),
   "nutrient.protein": z.number(),
   "nutrient.fat": z.number(),

--- a/src/api/user/recipes.ts
+++ b/src/api/user/recipes.ts
@@ -1,0 +1,71 @@
+import type { Token } from "@/types/auth";
+import { fetchYazio } from "@/utils/fetch";
+import { z } from "zod";
+
+export const RecipeServingSchema = z.object({
+  producer: z.string().nullable(),
+  name: z.string(),
+  amount: z.number(),
+  base_unit: z.string(),
+  serving: z.string().nullable(),
+  serving_quantity: z.number().nullable(),
+  note: z.string().nullable(),
+  product_id: z.string().uuid(),
+});
+
+export type RecipeServing = z.infer<typeof RecipeServingSchema>;
+
+export const RecipeSchema = z.object({
+  id: z.string().uuid(),
+  yazio_id: z.string().nullable(),
+  locale: z.string(),
+  name: z.string(),
+  portion_count: z.number(),
+  nutrients: z.record(z.string(), z.number()),
+  image: z.unknown(),
+  instructions: z.array(z.any()),
+  is_yazio_recipe: z.boolean(),
+  available_since: z.string().nullable(),
+  is_pro_recipe: z.boolean(),
+  servings: z.array(RecipeServingSchema),
+});
+
+export type Recipe = z.infer<typeof RecipeSchema>;
+
+/**
+ * Get a recipe by id.
+ *
+ * @param token - The token to use for authentication.
+ * @param recipeId - The UUID of the recipe.
+ *
+ * @returns - Promise resolving to the recipe.
+ */
+export const getRecipe = async (
+  token: Token,
+  recipeId: string
+): Promise<Recipe> =>
+  fetchYazio<Recipe>(`/recipes/${recipeId}`, {
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+      Accept: "application/json",
+    },
+  });
+
+/**
+ * Delete a user recipe by id.
+ *
+ * @param token - The token to use for authentication.
+ * @param recipeId - The UUID of the recipe to delete.
+ *
+ * @returns - Promise resolving when the recipe was deleted (204).
+ */
+export const deleteUserRecipe = async (
+  token: Token,
+  recipeId: string
+): Promise<void> =>
+  fetchYazio<void>(`/user/recipes/${recipeId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+    },
+  });

--- a/src/api/user/recipes.ts
+++ b/src/api/user/recipes.ts
@@ -22,8 +22,8 @@ export const RecipeSchema = z.object({
   name: z.string(),
   portion_count: z.number(),
   nutrients: z.record(z.string(), z.number()),
-  image: z.unknown(),
-  instructions: z.array(z.any()),
+  image: z.string().nullable(),
+  instructions: z.array(z.string()),
   is_yazio_recipe: z.boolean(),
   available_since: z.string().nullable(),
   is_pro_recipe: z.boolean(),
@@ -31,6 +31,24 @@ export const RecipeSchema = z.object({
 });
 
 export type Recipe = z.infer<typeof RecipeSchema>;
+
+/**
+ * Get the list of recipe IDs belonging to the user (no details).
+ * Use getRecipe(id) for each id to fetch full recipe data.
+ *
+ * @param token - The token to use for authentication.
+ *
+ * @returns - Promise resolving to an array of recipe UUIDs.
+ */
+export const getUserRecipeIds = async (
+  token: Token
+): Promise<string[]> =>
+  fetchYazio<string[]>(`/user/recipes`, {
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+      Accept: "application/json",
+    },
+  });
 
 /**
  * Get a recipe by id.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,7 +5,10 @@ export type {
   CredentialsResolver,
 } from "@/types/auth";
 
-import { getTokenFromCredentials } from "@/api/oauth/token";
+import {
+  getTokenFromCredentials,
+  getTokenFromRefreshToken,
+} from "@/api/oauth/token";
 import {
   YazioAuthInitSchema,
   type CredentialsResolver,
@@ -65,22 +68,31 @@ export class YazioAuth {
       return token;
     }
 
+    // If we have an expired token with refresh_token, try to refresh first.
+    const tokenToRefresh = token ?? this.cachedToken;
+    if (tokenToRefresh?.refresh_token) {
+      try {
+        const refreshedToken =
+          await getTokenFromRefreshToken(tokenToRefresh.refresh_token);
+        this.cachedToken = refreshedToken;
+        this.token = refreshedToken;
+        if (this.onRefresh) this.onRefresh({ token: refreshedToken });
+        return refreshedToken;
+      } catch {
+        // Refresh failed (e.g. refresh_token revoked); fall through to credentials.
+      }
+    }
+
     const credentials = await resolveCredentials(this.credentials);
     if (!credentials)
       throw new Error(
         "Unable to resolve credentials. Please make sure `credentials` is passed correctly."
       );
 
-    // If only credentials were provided or if the token expired, fetch a
-    // fresh one.
-    // TODO (@juriadams): Investigate if tere is an endpoint for refreshing
-    // tokens instead of fetching new ones every time.
-    const refreshedToken = await getTokenFromCredentials(credentials!);
+    const refreshedToken = await getTokenFromCredentials(credentials);
+    this.cachedToken = refreshedToken;
     this.token = refreshedToken;
-
-    // If a custom `onRefresh` handler is set, invoke it.
     if (this.onRefresh) this.onRefresh({ token: refreshedToken });
-
     return refreshedToken;
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   getUserWaterIntake,
   getUserWeight,
   getRecipe,
+  getUserRecipeIds,
   deleteUserRecipe,
   searchProducts,
   getUserDailySummary,
@@ -87,6 +88,9 @@ class User {
 
   public getRecipe = async (id: Parameters<typeof getRecipe>[1]) =>
     getRecipe(await this.auth.authenticate(), id);
+
+  public getRecipeIds = async () =>
+    getUserRecipeIds(await this.auth.authenticate());
 
   public deleteRecipe = async (id: Parameters<typeof deleteUserRecipe>[1]) =>
     deleteUserRecipe(await this.auth.authenticate(), id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import {
   getUserSuggestedProducts,
   getUserWaterIntake,
   getUserWeight,
+  getRecipe,
+  deleteUserRecipe,
   searchProducts,
   getUserDailySummary,
   addUserConsumedItem,
@@ -54,25 +56,25 @@ class User {
     getUserDietaryPreferences(await this.auth.authenticate());
 
   public getExercises = async (
-    options: Parameters<typeof getUserExercises>[1]
+    options?: Parameters<typeof getUserExercises>[1]
   ) => getUserExercises(await this.auth.authenticate(), options);
 
-  public getGoals = async (options: Parameters<typeof getUserGoals>[1]) =>
+  public getGoals = async (options?: Parameters<typeof getUserGoals>[1]) =>
     getUserGoals(await this.auth.authenticate(), options);
 
   public getSettings = async () =>
     getUserSettings(await this.auth.authenticate());
 
   public getWaterIntake = async (
-    options: Parameters<typeof getUserWaterIntake>[1]
+    options?: Parameters<typeof getUserWaterIntake>[1]
   ) => getUserWaterIntake(await this.auth.authenticate(), options);
 
   public getDailySummary = async (
-    options: Parameters<typeof getUserDailySummary>[1]
+    options?: Parameters<typeof getUserDailySummary>[1]
   ) => getUserDailySummary(await this.auth.authenticate(), options);
 
   public getConsumedItems = async (
-    options: Parameters<typeof getUserConsumedItems>[1]
+    options?: Parameters<typeof getUserConsumedItems>[1]
   ) => getUserConsumedItems(await this.auth.authenticate(), options);
 
   public addConsumedItem = async (
@@ -82,6 +84,12 @@ class User {
   public removeConsumedItem = async (
     options: Parameters<typeof removeUserConsumedItem>[1]
   ) => removeUserConsumedItem(await this.auth.authenticate(), options);
+
+  public getRecipe = async (id: Parameters<typeof getRecipe>[1]) =>
+    getRecipe(await this.auth.authenticate(), id);
+
+  public deleteRecipe = async (id: Parameters<typeof deleteUserRecipe>[1]) =>
+    deleteUserRecipe(await this.auth.authenticate(), id);
 }
 
 export class Yazio {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const YAZIO_BASE_URL = "https://yzapi.yazio.com/v15";
+export const YAZIO_BASE_URL = "https://yzapi.yazio.com/v20";
 
 export const YAZIO_CLIENT_ID =
   "1_4hiybetvfksgw40o0sog4s884kwc840wwso8go4k8c04goo4c";

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -83,6 +83,35 @@ describe("auth", () => {
     });
   });
 
+  describe("token refresh", () => {
+    test("uses refresh_token when token expired and credentials available", async () => {
+      const authWithCreds = new YazioAuth({
+        credentials: {
+          username: Bun.env.YAZIO_USERNAME!,
+          password: Bun.env.YAZIO_PASSWORD!,
+        },
+      });
+      const firstToken = await authWithCreds.authenticate();
+      expect(firstToken.refresh_token).toBeDefined();
+
+      const expiredToken: Token = {
+        ...firstToken,
+        expires_at: Date.now() - 1000,
+      };
+      const authWithExpiredToken = new YazioAuth({
+        credentials: {
+          username: Bun.env.YAZIO_USERNAME!,
+          password: Bun.env.YAZIO_PASSWORD!,
+        },
+        token: expiredToken,
+      });
+      const refreshed = await authWithExpiredToken.authenticate();
+      const parsed = TokenSchema.safeParse(refreshed);
+      expect(parsed.success).toBe(true);
+      expect(refreshed.access_token).not.toBe(expiredToken.access_token);
+    });
+  });
+
   describe("token", () => {
     test("directly passing a token", async () => {
       const auth = new YazioAuth({

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,19 +1,151 @@
-import { describe, test } from "bun:test";
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
 
 import { Yazio } from "@/index";
+import { UserSchema, type User } from "@/api/user/index";
+import {
+  UserWeightSchema,
+  type UserWeight,
+} from "@/api/user/bodyvalues/weight";
+import {
+  UserSuggestedProductSchema,
+  type UserSuggestedProduct,
+} from "@/api/user/products/suggested";
+import {
+  UserDietaryPreferencesSchema,
+  type UserDietaryPreferences,
+} from "@/api/user/diet";
+import { ExerciseSchema } from "@/api/user/exercises";
+import { UserGoalsSchema, type UserGoals } from "@/api/user/goals";
+import { UserSettingsSchema, type UserSettings } from "@/api/user/settings";
+import {
+  UserWaterIntakeSchema,
+  type UserWaterIntake,
+} from "@/api/user/water";
+import {
+  UserDailySummarySchema,
+  type UserDailySummary,
+} from "@/api/user/summary";
+import {
+  GetUserConsumedItemsResponseSchema,
+  type GetUserConsumedItemsResponse,
+} from "@/api/user/consumed";
+import { RecipeSchema, type Recipe } from "@/api/user/recipes";
+
+const ExercisesResponseSchema = z.object({
+  training: z.array(ExerciseSchema),
+  custom_training: z.array(ExerciseSchema),
+});
+type ExercisesResponse = z.infer<typeof ExercisesResponseSchema>;
+
+function createYazio() {
+  if (!Bun.env.YAZIO_USERNAME || !Bun.env.YAZIO_PASSWORD) {
+    throw new Error(
+      "YAZIO_USERNAME and YAZIO_PASSWORD must be set in env to run user tests"
+    );
+  }
+  return new Yazio({
+    credentials: {
+      username: Bun.env.YAZIO_USERNAME,
+      password: Bun.env.YAZIO_PASSWORD,
+    },
+  });
+}
 
 describe("user", () => {
-  describe("consumed items", () => {
-    test("add a specific amount to the diary", async () => {
-      const yazio = new Yazio({
-        credentials: {
-          username: Bun.env.YAZIO_USERNAME!,
-          password: Bun.env.YAZIO_PASSWORD!,
-        },
-      });
+  describe("response shape validation", () => {
+    test("get returns valid user shape", async () => {
+      const yazio = createYazio();
+      const result: User = await yazio.user.get();
+      const parsed = UserSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
 
+    test("getWeight returns valid weight or null", async () => {
+      const yazio = createYazio();
+      const result: UserWeight | null = await yazio.user.getWeight();
+      if (result === null) return;
+      const parsed = UserWeightSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getSuggestedProducts returns valid array shape", async () => {
+      const yazio = createYazio();
+      const result: UserSuggestedProduct[] =
+        await yazio.user.getSuggestedProducts({ daytime: "breakfast" });
+      const parsed = z.array(UserSuggestedProductSchema).safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getDietaryPreferences returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: UserDietaryPreferences =
+        await yazio.user.getDietaryPreferences();
+      const parsed = UserDietaryPreferencesSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getExercises returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: ExercisesResponse = await yazio.user.getExercises();
+      const parsed = ExercisesResponseSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getGoals returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: UserGoals = await yazio.user.getGoals();
+      const parsed = UserGoalsSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getSettings returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: UserSettings = await yazio.user.getSettings();
+      const parsed = UserSettingsSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getWaterIntake returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: UserWaterIntake = await yazio.user.getWaterIntake();
+      const parsed = UserWaterIntakeSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getDailySummary returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: UserDailySummary = await yazio.user.getDailySummary();
+      const parsed = UserDailySummarySchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getConsumedItems returns valid shape", async () => {
+      const yazio = createYazio();
+      const result: GetUserConsumedItemsResponse =
+        await yazio.user.getConsumedItems();
+      const parsed = GetUserConsumedItemsResponseSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    test("getRecipe returns valid recipe shape when user has recipe portions", async () => {
+      const yazio = createYazio();
+      const consumed: GetUserConsumedItemsResponse =
+        await yazio.user.getConsumedItems();
+      const recipeId = consumed.recipe_portions[0]?.recipe_id;
+      if (!recipeId) return; // skip if no recipe portions
+      const result: Recipe = await yazio.user.getRecipe(recipeId);
+      const parsed = RecipeSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe("consumed items", () => {
+    test("add a specific amount then remove (clean up for prod user)", async () => {
+      const yazio = createYazio();
+      const entryId = crypto.randomUUID();
       await yazio.user.addConsumedItem({
-        id: crypto.randomUUID(),
+        id: entryId,
         product_id: "9e219ae8-becf-11e6-b9dc-e0071b8a8723",
         date: new Date(),
         daytime: "breakfast",
@@ -21,18 +153,14 @@ describe("user", () => {
         serving: null,
         serving_quantity: null,
       });
+      await yazio.user.removeConsumedItem(entryId);
     });
 
-    test("add a serving to the diary", async () => {
-      const yazio = new Yazio({
-        credentials: {
-          username: Bun.env.YAZIO_USERNAME!,
-          password: Bun.env.YAZIO_PASSWORD!,
-        },
-      });
-
+    test("add a serving then remove (clean up for prod user)", async () => {
+      const yazio = createYazio();
+      const entryId = crypto.randomUUID();
       await yazio.user.addConsumedItem({
-        id: crypto.randomUUID(),
+        id: entryId,
         product_id: "9e219ae8-becf-11e6-b9dc-e0071b8a8723",
         date: new Date(),
         daytime: "breakfast",
@@ -40,18 +168,14 @@ describe("user", () => {
         serving: "roll",
         serving_quantity: 1,
       });
+      await yazio.user.removeConsumedItem(entryId);
     });
 
-    test("add multiple servings to the diary", async () => {
-      const yazio = new Yazio({
-        credentials: {
-          username: Bun.env.YAZIO_USERNAME!,
-          password: Bun.env.YAZIO_PASSWORD!,
-        },
-      });
-
+    test("add multiple servings then remove (clean up for prod user)", async () => {
+      const yazio = createYazio();
+      const entryId = crypto.randomUUID();
       await yazio.user.addConsumedItem({
-        id: crypto.randomUUID(),
+        id: entryId,
         product_id: "9e219ae8-becf-11e6-b9dc-e0071b8a8723",
         date: new Date(),
         daytime: "breakfast",
@@ -59,6 +183,7 @@ describe("user", () => {
         serving: "roll",
         serving_quantity: 2,
       });
+      await yazio.user.removeConsumedItem(entryId);
     });
   });
 });

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -138,6 +138,13 @@ describe("user", () => {
       const parsed = RecipeSchema.safeParse(result);
       expect(parsed.success).toBe(true);
     });
+
+    test("getRecipeIds returns valid array of UUIDs", async () => {
+      const yazio = createYazio();
+      const result: string[] = await yazio.user.getRecipeIds();
+      const parsed = z.array(z.string().uuid()).safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
   });
 
   describe("consumed items", () => {


### PR DESCRIPTION
## Summary

- **API version:** base URL switched from v15 to v20
- **Recipes:** `user.getRecipe(id)`, `user.getRecipeIds()`, `user.deleteRecipe(id)` (GET /recipes/:id, GET /user/recipes, DELETE /user/recipes/:id)
- **Consumed types:** `recipe_portions` and `simple_products` fully typed in `getUserConsumedItems` response
- **Goals:** export `UserGoalsSchema` for validation
- **User API tests:** Zod response shape validation for all `user.*` methods; consumed items tests add then remove (cleanup for prod user)
- **Tests:** throw clear error when `YAZIO_USERNAME` / `YAZIO_PASSWORD` are missing

## Token refresh (fixes #4)

- **`getTokenFromRefreshToken(refreshToken)`** in `api/oauth/token.ts`: calls `/oauth/token` with `grant_type: refresh_token`, `client_id`, `client_secret`, `refresh_token`
- **YazioAuth:** when token is expired but has `refresh_token`, tries refresh first; falls back to credentials (password grant) if refresh fails
- **Export:** `getTokenFromRefreshToken` from `api`
- **Test:** "uses refresh_token when token expired and credentials available" in auth tests

## Recipes (list + types)

- **`getUserRecipeIds(token)`** → `GET /user/recipes` → array of recipe UUIDs (no query params)
- **`user.getRecipeIds()`** in client
- **Recipe types:** `image` `string | null`, `instructions` `string[]`
- **Flow:** getRecipeIds() → ids; getRecipe(id) per id; deleteRecipe(id) for remove